### PR TITLE
Added rl_completer_quote_characters

### DIFF
--- a/rlcompleter.c
+++ b/rlcompleter.c
@@ -127,6 +127,7 @@ int luaopen_rlcompleter_c (lua_State *L)
   luaL_openlib (L, LCOMPLETERLIBNAME, lib, 0);
   storedL = L;
   rl_basic_word_break_characters = " \t\n\"\\'><=;:+-*/%^~#{}()[].,";
+  rl_completer_quote_characters = "\"'";
   rl_attempted_completion_function = do_completion;
   return 1;
 }


### PR DESCRIPTION
Added rl_completer_quote_characters to avoid problems in auto-completion of strings with spaces, dots, hyphens, etc.

I had problems when completing filenames like the following:

```
$ lua5.1 
Lua 5.1.5  Copyright (C) 1994-2012 Lua.org, PUC-Rio
> require "rlcompleter"
> l = "BigDat-2015-Talia<TAB>
BigDat-2015-Talia - Lesson 1.pdf  BigDat-2015-Talia - Lesson 2.pdf  BigDat-2015-Talia_-_Lesson_3.pdf  
> l = "BigDat-2015-Talia <TAB>
20150126 BigDat - MdR.zip                                    all.pdf                                                      bigvideo.avi
BigDat-2015-Talia - Lesson 1.pdf                             big1.pdf                                                     https___powerpoint.officeapps.live.com_p_printhandler.pdf
BigDat-2015-Talia - Lesson 2.pdf                             big2.pdf                                                     minos-bigdat2015-2up.pdf
BigDat-2015-Talia_-_Lesson_3.pdf                             big3.pdf                                                     pitoura-material.zip
Blockeel-1.pdf                                               bigdat-2015-calvanese-overview.pdf                           rlcompleter.lua
Blockeel-2.pdf                                               bigdat-2015-calvanese-part-1.pdf                             rlcompleter_c.so
Blockeel-3.pdf                                               bigdat-2015-calvanese-part-2.pdf                             tarragona.pptx
VisualAnalyticsofTimeVaryingGraphs-Slides-Raghavan2 (1).pdf  bigdat-2015-calvanese-part-3.pdf                             tarragonaAll.pdf
> s = "BigDat-2015-Talia - Lesson 1.pdf" -- written by hand, not auto-completed
```

With this modification it is working as expected, following filenames auto-completion even when they contain break chars:

```
$ lua5.1 
Lua 5.1.5  Copyright (C) 1994-2012 Lua.org, PUC-Rio
> require "rlcompleter"
> s = "BigDat-2015-Talia<TAB>
BigDat-2015-Talia - Lesson 1.pdf  BigDat-2015-Talia - Lesson 2.pdf  BigDat-2015-Talia_-_Lesson_3.pdf  
> s = "BigDat-2015-Talia <TAB>
> s = "BigDat-2015-Talia - Lesson <TAB>
BigDat-2015-Talia - Lesson 1.pdf  BigDat-2015-Talia - Lesson 2.pdf  
> s = "BigDat-2015-Talia - Lesson 1<TAB>
> s = "BigDat-2015-Talia - Lesson 1.pdf"
```
